### PR TITLE
Minor typo and remove data download instruction

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -32,7 +32,7 @@ keypoints:
 >
 > This episode will be a quick introduction to the Unix shell, only the bare minimum required to use the cluster.
 >
-> The Software Carpentary '[Unix Shell](https://swcarpentry.github.io/shell-novice/)' lesson covers the subject in more depth, we recommend you check it out.
+> The Software Carpentry '[Unix Shell](https://swcarpentry.github.io/shell-novice/)' lesson covers the subject in more depth, we recommend you check it out.
 >
 {: .callout}
 

--- a/index.md
+++ b/index.md
@@ -30,8 +30,7 @@ By the end of this workshop, students will know how to:
 > ## Getting Started
 >
 > To get started, follow the directions in the "[Setup](
-> {{ page.root }}/setup.html)" tab to download data to your computer and follow
-> any installation instructions.
+> {{ page.root }}/setup.html)" tab and follow any installation instructions.
 {: .callout}
 
 Note that this is the draft HPC Carpentry release. Comments and feedback are


### PR DESCRIPTION
Hi,

This PR fixes a typo in Carpentry name and remove an instructions about downloading data, which could be confusing as there is no data to download in the setup step.