### PR TITLE
One way to could think about simplifying the parallel section.

### DIFF
--- a/_episodes/064-parallel.md
+++ b/_episodes/064-parallel.md
@@ -67,7 +67,12 @@ Number of threads to use is specified by the Slurm option `--cpus-per-task`.
 > #SBATCH --mem-per-cpu     500
 > #SBATCH --cpus-per-task   8
 > 
-> echo "I am task #${SLURM_PROCID} running on node '$(hostname)' with $(nproc) CPUs"
+> echo -ne "Slurm Task ID:\t"
+> echo ${SLURM_PROCID}
+> echo -ne "On Node: \t"
+> echo $(hostname)
+> echo -n "Number of CPUs: "
+> echo $(nproc)
 > ```
 > {: .language-bash}
 >


### PR DESCRIPTION
This is really just a thought, but we could simplify the shell stuff by breaking it into multiple lines, similar to what we do in the preceding lesson.

I couldn't resist using echo with no newlines and interpreting escapes which is maybe a bridge to far though.

I just modified the first example as a conversation starter.