### PR TITLE
Changes to sum_matrix to work more reliably under MPI

### DIFF
--- a/_includes/example_scripts/sum_matrix.r
+++ b/_includes/example_scripts/sum_matrix.r
@@ -1,55 +1,51 @@
 #!/usr/bin/env Rscript
 
-
 # Function for shared memory execution
-doTask <- function(size_x, size_y, seed, print_progress){
+doTask <- function(size_x, size_y, seed, print_progress) {
     suppressPackageStartupMessages(library(doParallel))
-
-    message(sprintf("Summing [ %e x %e ] matrix, seed = '%i'",size_x,size_y, seed))
-    message(sprintf("Running on '%s' with %i CPU(s).", Sys.info()["nodename"], num_cpus))
-
+    message(sprintf("Summing [ %e x %e ] matrix, seed = '%i'", size_x, size_y, seed))
     set.seed(seed)
 
-    registerDoParallel((num_cpus/2))
+    registerDoParallel(num_cpus)
 
-    results_all <- foreach(z=0:size_x) %dopar% {
-        percent_complete= z*100/size_x
-        if (print_progress && percent_complete%%1==0){
+    results_all <- foreach(z = 1:size_x, .combine = "+") %dopar% {
+        percent_complete = z * 100 / size_x
+        if (print_progress && percent_complete %% 1 == 0) {
             message(sprintf(" %i%% done...\r", percent_complete))
         }
         sum(rnorm(size_y))
     }
-    Reduce("+",results_all)
+    results_all
 }
 
-# 50 calculations, store the result in 'x'
+# Get SLURM environment variables
+ntasks <- as.integer(Sys.getenv('SLURM_NTASKS', unset = "1"))
+seed <- as.integer(Sys.getenv('SLURM_ARRAY_TASK_ID', unset = "0"))
+num_cpus <- as.integer(Sys.getenv('SLURM_CPUS_PER_TASK', unset = "1"))
 
-ntasks <- strtoi(Sys.getenv('SLURM_NTASKS', unset = "1")) 
-seed <- strtoi(Sys.getenv('SLURM_ARRAY_TASK_ID', unset = "0"))
-num_cpus <- as.integer(strtoi(Sys.getenv('SLURM_CPUS_PER_TASK', unset = "1")))
-
-size_x <-60000 # This on makes memorier
-size_y <-40000 # This one to make longer
-
-# Time = (size_x/n) * size_y + c
-# Mem  = (size_x * n) * c1 + size_y * c2
+size_x <- 60000 # This on makes memorier
+size_y <- 40000 # This one to make longer
 
 print_progress <- TRUE
-# print_progress <- interactive() # Whether to print progress or not.
 
-#If more than 1 task, use doMPI 
-if (ntasks > 1){
-    suppressPackageStartupMessages(library(doSNOW))
-     cl <- makeMPIcluster(outfile="")
+# Check if we're running with multiple tasks
+if (ntasks > 1) {
+    message(sprintf("MPI Running on '%s' with %i CPU(s)", Sys.info()["nodename"], num_cpus))
+    suppressPackageStartupMessages(library(doMPI))
+    cl <- startMPIcluster()
+    registerDoMPI(cl)
 
-    results_all <- foreach(z=1:ntasks) %dopar% {
-        doTask(size_x, ceiling(size_y/ntasks), z+seed, print_progress)
+    results_all <- foreach(z = 1:ntasks, .combine = "+") %dopar% {
+        doTask(size_x, ceiling(size_y / ntasks), z + seed, print_progress)
     }
-    
-    results = Reduce("+",results_all)
-    stopCluster(cl)
-    message(sprintf("Sums to %f", results))
-}else{
-    results = doTask(size_x, size_y, seed, print_progress)
-    message(sprintf("Sums to %f", results))
+
+    results <- Reduce("+", results_all)
+    closeCluster(cl)
+    message(sprintf("MPI Sums to %f", results))
+    mpi.quit()
+} else {
+    message("Running non-MPI task")
+    message(sprintf("Shared Memory Running on '%s' with %i CPU(s)", Sys.info()["nodename"], num_cpus))
+    results <- doTask(size_x, size_y, seed, print_progress)
+    message(sprintf("(Non-MPI) Sums to %f", results))
 }


### PR DESCRIPTION
Changes to sum_matrix to work more reliably under MPI

Changed from doSNOW to doMPI, changed the printout to partially
occur outside the function so that printouts of nodenames works
under MPI

Changed the shared mem version from dividing ncpu/2 as this gives a
nicer comparison with the MPI version, but maybe that's confusing.
![mv-vs-mpi](https://github.com/user-attachments/assets/3b9b5320-d0f6-47bc-8436-4c7a614ef24d)
